### PR TITLE
Chris

### DIFF
--- a/pulsar_spectra/models.py
+++ b/pulsar_spectra/models.py
@@ -4,7 +4,7 @@ Spectral models from Jankowski et al. 2018 and references within
 
 import numpy as np
 
-def simple_power_law(v, a, b):
+def simple_power_law(v, a, b, v0):
     """Simple power law:
 
     .. math::
@@ -20,16 +20,17 @@ def simple_power_law(v, a, b):
         Spectral Index.
     b : `float`
         Constant.
+    v0 : `float`
+        Reference frequency.
 
     Returns
     -------
     S_v : `list`
         The flux density predicted by the model.
     """
-    v0 = 1.3e9
     return b*(v/v0)**a
 
-def broken_power_law(v, vb, a1, a2, b):
+def broken_power_law(v, vb, a1, a2, b, v0):
     """Broken power law:
 
     .. math::
@@ -49,13 +50,14 @@ def broken_power_law(v, vb, a1, a2, b):
         The spectral index after the break.
     b : `float`
         Constant.
+    v0 : `float`
+        Reference frequency.
 
     Returns
     -------
     S_v : `list`
         The flux density predicted by the model.
     """
-    v0 = 1.3e9
     x = v / v0
     xb = vb / v0
     y1 = b*x**a1
@@ -72,7 +74,7 @@ def double_broken_power_law(v, vb1, vb2, a1, a2, a3, b):
     y3 = b*x**a3*(xb2)**(a2-a3)
     return np.piecewise(x, [x <= xb1, (x > xb1) & (x <= xb2), x > xb2], [y1, y2, y3])
 
-def log_parabolic_spectrum(v, a, b, c):
+def log_parabolic_spectrum(v, a, b, c, v0):
     """Log-parabolic spectrum:
 
     .. math::
@@ -90,17 +92,18 @@ def log_parabolic_spectrum(v, a, b, c):
         The spectral index for :math:`a = 0`.
     c : `float`
         Constant.
+    v0 : `float`
+        Reference frequency.
 
     Returns
     -------
     S_v : `list`
         The flux density predicted by the model.
     """
-    v0 = 1.3e9
     x = np.log10( v / v0 )
     return 10**(a*x**2 + b*x + c)
 
-def high_frequency_cut_off_power_law(v, vc, a, b):
+def high_frequency_cut_off_power_law(v, vc, b, v0):
     """Power law with high-frequency cut-off off:
 
     .. math::
@@ -114,24 +117,23 @@ def high_frequency_cut_off_power_law(v, vc, a, b):
         Frequency in Hz.
     v_c : `list`
         Cut off frequency in Hz.
-    a : `float`
-        The spectral index before the power cut-off.
     b : `float`
         Constant.
+    v0 : `float`
+        Reference frequency.
 
     Returns
     -------
     S_v : `list`
         The flux density predicted by the model.
     """
-    v0 = 1.3e9
     x = v / v0
     xc = vc / v0
     y1 = b*x**(-2) * ( 1 - x / xc )
-    y2 = b*x**a
+    y2 = 0
     return np.where(x < xc, y1, y2)
 
-def low_frequency_turn_over_power_law(v, vc, a, b, beta):
+def low_frequency_turn_over_power_law(v, vc, a, b, beta, v0):
     """power law with low-frequency turn-over:
 
     .. math::
@@ -151,13 +153,14 @@ def low_frequency_turn_over_power_law(v, vc, a, b, beta):
         Constant.
     beta : `float`
         The smoothness of the turn-over.
+    v0 : `float`
+        Reference frequency.
 
     Returns
     -------
     S_v : `list`
         The flux density predicted by the model.
     """
-    v0 = 1.3e9
     x = v / v0
     xc = v / vc
     return b * x**a * np.exp( a / beta * xc**(-beta) )

--- a/pulsar_spectra/spectral_fit.py
+++ b/pulsar_spectra/spectral_fit.py
@@ -350,6 +350,10 @@ def find_best_spectral_fit(pulsar, freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all,
         The Minuit class after being fit in :py:meth:`pulsar_spectra.spectral_fit.iminuit_fit_spectral_model`.
     fit_info : `str`
         The string to label the fit with from :py:meth:`pulsar_spectra.spectral_fit.iminuit_fit_spectral_model`.
+    p_best : `float`
+        The probability that the best-fit model is actually the best-fit model.
+    p_category : `str`
+        Category based on the quality of spectral fit, as defined in Jankowski et al. (2018).
     """
     # Prepare plots and fitting frequencies
     if plot_compare:

--- a/pulsar_spectra/spectral_fit.py
+++ b/pulsar_spectra/spectral_fit.py
@@ -19,15 +19,6 @@ from pulsar_spectra.catalogues import convert_cat_list_to_dict
 import logging
 logger = logging.getLogger(__name__)
 
-def log_centre(v):
-    """Find logarithmic centre frequency.
-    """
-    if isinstance(v, list):
-        return 10**((np.log10(min(v))+np.log10(max(v)))/2)
-    else:
-        print("Defaulting to 1.3 GHz")
-        return 1.3e9
-
 def robust_cost_function(f_y, y, sigma_y, k=1.345):
     beta_array = []
     for fi, yi, sigma_i in zip(f_y, y, sigma_y):
@@ -252,7 +243,7 @@ def iminuit_fit_spectral_model(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref, model=s
                 The frequency range of the fitted data in the form (min, max).
     """
     # Covert to SI (Hz and Jy)
-    v0_Hz        = log_centre(freqs_MHz) * 1e6 # reference frequency is the logarithmic centre frequency
+    v0_Hz        = 10**((np.log10(min(freqs_MHz))+np.log10(max(freqs_MHz)))/2) * 1e6 # reference frequency is the logarithmic centre frequency
     freqs_Hz     = np.array(freqs_MHz,     dtype=np.float128) * 1e6
     fluxs_Jy     = np.array(fluxs_mJy,     dtype=np.float128) / 1e3
     flux_errs_Jy = np.array(flux_errs_mJy, dtype=np.float128) / 1e3

--- a/pulsar_spectra/spectral_fit.py
+++ b/pulsar_spectra/spectral_fit.py
@@ -19,6 +19,15 @@ from pulsar_spectra.catalogues import convert_cat_list_to_dict
 import logging
 logger = logging.getLogger(__name__)
 
+def log_centre(v):
+    """Find logarithmic centre frequency.
+    """
+    if isinstance(v, list):
+        return 10**((np.log10(min(v))+np.log10(max(v)))/2)
+    else:
+        print("Defaulting to 1.3 GHz")
+        return 1.3e9
+
 def robust_cost_function(f_y, y, sigma_y, k=1.345):
     beta_array = []
     for fi, yi, sigma_i in zip(f_y, y, sigma_y):
@@ -228,41 +237,55 @@ def iminuit_fit_spectral_model(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref, model=s
         The Minuit class after being fit in :py:meth:`pulsar_spectra.spectral_fit.iminuit_fit_spectral_model`.
     fit_info : `str`
         The string to label the fit with from :py:meth:`pulsar_spectra.spectral_fit.iminuit_fit_spectral_model`.
+    best_fit : `dict`
+        Dictionary of best-fit model parameters in the format best_fit['Model', 'Parameters', 'Values', 'Errors', 'Fit Range']
+
+            ``'Model'`` : `str`
+                The name of the analytical model.
+            ``'Parameters'`` : `list`
+                The fitted parameters.
+            ``'Values'`` : `list`
+                The best-fit parameter values.
+            ``'Errors'`` : `list`
+                The 1-sigma uncertainty on each parameter value.
+            ``'Fit Range'`` : `tuple`
+                The frequency range of the fitted data in the form (min, max).
     """
     # Covert to SI (Hz and Jy)
+    v0_Hz        = log_centre(freqs_MHz) * 1e6 # reference frequency is the logarithmic centre frequency
     freqs_Hz     = np.array(freqs_MHz,     dtype=np.float128) * 1e6
     fluxs_Jy     = np.array(fluxs_mJy,     dtype=np.float128) / 1e3
     flux_errs_Jy = np.array(flux_errs_mJy, dtype=np.float128) / 1e3
 
     # Model dependent defaults
     if model == simple_power_law:
-        # a, b
-        start_params = (-1.6, 0.003)
-        mod_limits = [(None, 0), (0, None)]
+        # a, b, v0
+        start_params = (-1.6, 0.003, v0_Hz)
+        mod_limits = [(None, 0), (0, None), None]
     elif model == broken_power_law:
-        # vb, a1, a2, b
-        start_params = (5e8, -1.6, -1.6, 0.1)
-        mod_limits = [(min(freqs_Hz)+1e8, max(freqs_Hz)-1e8), (-10, 10), (-10, 0), (0, None)]
+        # vb, a1, a2, b, v0
+        start_params = (5e8, -1.6, -1.6, 0.1, v0_Hz)
+        mod_limits = [(min(freqs_Hz)+1e8, max(freqs_Hz)-1e8), (-10, 10), (-10, 0), (0, None), None]
     elif model == double_broken_power_law:
-        # vb1, vb2, a1, a2, a3, b
-        start_params = (5e8, 5e8, -2.6, -2.6, -2.6, 0.1)
-        mod_limits = [(1e3, 1e9), (1e3, 1e9), (None, 0), (None, 0), (None, 0), (0, None)]
+        # vb1, vb2, a1, a2, a3, b, v0
+        start_params = (5e8, 5e8, -2.6, -2.6, -2.6, 0.1, v0_Hz)
+        mod_limits = [(1e3, 1e9), (1e3, 1e9), (None, 0), (None, 0), (None, 0), (0, None), None]
     elif model == log_parabolic_spectrum:
-        # a, b, c
-        start_params = (-1.6, 1., 1.)
-        mod_limits = [(-5, 2), (-5, 2), (None, None)]
+        # a, b, c, v0
+        start_params = (-1.6, 1., 1., v0_Hz)
+        mod_limits = [(-5, 2), (-5, 2), (None, None), None]
     elif model == high_frequency_cut_off_power_law:
-        # vc, a, b
-        start_params = (4e9, -1.6, 1.)
-        mod_limits = [(3e9, 1e12), (None, 0), (0, None)]
+        # vc, b, v0
+        start_params = (4e9, 1., v0_Hz)
+        mod_limits = [(3e9, 1e12), (0, None), None]
     elif model == low_frequency_turn_over_power_law:
-        # vc, a, b, beta
-        start_params = (100e6, -2.5, 1.e1, 1.)
-        mod_limits = [(10e6, 500e6), (-5, -.5), (0, 100) , (.1, 2.1)]
+        # vc, a, b, beta, v0
+        start_params = (100e6, -2.5, 1.e1, 1., v0_Hz)
+        mod_limits = [(10e6, 500e6), (-5, -.5), (0, 100) , (.1, 2.1), None]
 
     # Check if enough inputs
     model_str = str(model).split(" ")[1]
-    k = len(start_params) # number of model parameters
+    k = len(start_params)-1 # number of free model parameters
     if len(freqs_MHz) <= k + 1:
         logger.warn(f"Only {len(freqs_MHz)} supplied for {model_str} model fit. This is not enough so skipping")
         return 1e9, None, None
@@ -271,18 +294,40 @@ def iminuit_fit_spectral_model(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref, model=s
     least_squares = LeastSquares(freqs_Hz, fluxs_Jy, flux_errs_Jy, model)
     least_squares.loss = huber_loss_function
     m = Minuit(least_squares, *start_params)
-    m.tol=0.01
-    m.limits = mod_limits
-    m.scan(ncall=500)
-    m.migrad(ncall=300)  # finds minimum of least_squares function
+    m.fixed["v0"] = True # fix the reference frequency
+
+    """Find the minimum of least_squares function using the in-built minimisation
+    algorithms in iminuit. If migrad by itself fails, then run the simplex
+    minimiser before migrad. If simplex fails, run a grid scan over parameter
+    space before migrad. Systematically increase the number of calls until
+    a valid minimum is found.
+    """
+    m.tol=0.00001 # low tolerace improves likelihood of a sensible fit
+    m.limits = mod_limits # limits are primarily to assist the scan minimiser
+    migrad_calls = 10000 # more calls, better fit
+    m.migrad(ncall=migrad_calls)
     if not m.valid:
-        # Failed so try simplix method
-        m.simplex(ncall=300)
-        m.migrad(ncall=300)
+        m.simplex(ncall=1000)
+        m.migrad(ncall=migrad_calls)
     if not m.valid:
-        # Use scan
-        m.migrad(ncall=500)
-    m.hesse()   # accurately computes uncertainties
+        m.scan(ncall=1000)
+        m.migrad(ncall=migrad_calls)
+    if not m.valid:
+        m.simplex(ncall=10000)
+        m.migrad(ncall=migrad_calls)
+    if not m.valid:
+        m.scan(ncall=10000)
+        m.migrad(ncall=migrad_calls)
+    if not m.valid:
+        m.simplex(ncall=20000)
+        m.migrad(ncall=migrad_calls)
+    if not m.valid:
+        m.scan(ncall=20000)
+        m.migrad(ncall=migrad_calls)
+    if not m.valid:
+        print(f"No valid minimum found for model {model_str}.")
+
+    m.hesse() # accurately computes uncertainties
     logger.debug(m)
 
     # display legend with some fit info
@@ -294,6 +339,13 @@ def iminuit_fit_spectral_model(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref, model=s
             fit_info.append(f"{p} = ${v:.5f} \\pm {e:.5}$")
     fit_info = "\n".join(fit_info)
 
+    best_fit = {} # create dictionary of best-fit parameters
+    best_fit["Model"] = model_str
+    best_fit["Parameters"] = m.parameters
+    best_fit["Values"] = [*m.values] # convert iminuit object to list
+    best_fit["Errors"] = [*m.errors]
+    best_fit["Fit Range"] = (min(freqs_MHz), max(freqs_MHz))
+
     # Calculate AIC
     beta = robust_cost_function(model(freqs_Hz, *m.values), fluxs_Jy, flux_errs_Jy)
     aic = 2*beta + 2*k + (2*k*(k+1)) / (len(freqs_Hz) - k -1)
@@ -304,7 +356,7 @@ def iminuit_fit_spectral_model(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref, model=s
                 alternate_style=alternate_style, axis=axis,
                 secondary_fit=secondary_fit, fit_range=fit_range)
 
-    return aic, m, fit_info
+    return aic, m, fit_info, best_fit
 
 
 def find_best_spectral_fit(pulsar, freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all,
@@ -354,6 +406,21 @@ def find_best_spectral_fit(pulsar, freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all,
         The probability that the best-fit model is actually the best-fit model.
     p_category : `str`
         Category based on the quality of spectral fit, as defined in Jankowski et al. (2018).
+    best_fits : `dict`
+        Dictionary of best_fit dictionaries in the form best_fits[model_str]['Model', 'Parameters', 'Values', 'Errors', 'Fit Range']
+
+            ``'model_str'`` : `str`
+                The name of the analytical model.
+            ``'Model'`` : `str`
+                The name of the analytical model.
+            ``'Parameters'`` : `list`
+                The fitted parameters.
+            ``'Values'`` : `list`
+                The best-fit parameter values.
+            ``'Errors'`` : `list`
+                The 1-sigma uncertainty on each parameter value.
+            ``'Fit Range'`` : `tuple`
+                The frequency range of the fitted data in the form (min, max).
     """
     # Prepare plots and fitting frequencies
     if plot_compare:
@@ -376,12 +443,14 @@ def find_best_spectral_fit(pulsar, freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all,
     iminuit_results = []
     fit_infos = []
     model_i = []
+    best_fits = {} # make dictionary of best-fit parameters for all models
     for i, model_pair in enumerate(models):
         model, label = model_pair
-        aic, iminuit_result, fit_info = iminuit_fit_spectral_model(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all,
+        aic, iminuit_result, fit_info, best_fit = iminuit_fit_spectral_model(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all,
                         model=model, plot=plot_all, plot_error=plot_error, save_name=f"{pulsar}_{label}_fit.png",
                         alternate_style=alternate_style, axis=axis, secondary_fit=secondary_fit)
         logger.debug(f"{label} model fit gave AIC {aic}.")
+        best_fits[label] = best_fit
         if iminuit_result is not None:
             aics.append(aic)
             iminuit_results.append(iminuit_result)
@@ -394,7 +463,6 @@ def find_best_spectral_fit(pulsar, freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all,
                 plot_fit(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all, model, iminuit_result, fit_info,
                          plot_error=plot_error, alternate_style=alternate_style,
                          axis=axs[i], secondary_fit=secondary_fit, fit_range=fit_range)
-
 
     # Return best result
     if len(aics) == 0:
@@ -437,7 +505,7 @@ def find_best_spectral_fit(pulsar, freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all,
             plot_fit(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all, models[model_i[aici]][0], iminuit_results[aici], fit_infos[aici],
                     save_name=f"{pulsar}_{models[model_i[aici]][1]}_fit.png", plot_error=plot_error, alternate_style=alternate_style,
                     axis=axis, secondary_fit=secondary_fit, fit_range=fit_range)
-        return models[model_i[aici]], iminuit_results[aici], fit_infos[aici], p_best, p_category
+        return models[model_i[aici]], iminuit_results[aici], fit_infos[aici], p_best, p_category, best_fits
 
 
 def estimate_flux_density(

--- a/pulsar_spectra/spectral_fit.py
+++ b/pulsar_spectra/spectral_fit.py
@@ -100,10 +100,8 @@ def plot_fit(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref, model, iminuit_result, fi
     plotsize = 3.2
 
     if axis is None:
-        make_plot = True
         fig, ax = plt.subplots(figsize=(plotsize*4/3, plotsize))
     else:
-        make_plot = False
         ax = axis
     marker_scale = 0.7
     capsize = 1.5


### PR DESCRIPTION
i) The reference frequency used in each model is now the logarithmic centre frequency of the data set. I have tested this and in general the fits seem more sensible.
ii) The pl high cut-off model is now 0 above the cut-off, rather than another power law. This corrects the number of fit parameters and also fixes a problem I had where the cut-off frequency had zero uncertainty.
iii) The model fitting now exports a dictionary of the best-fit parameters, errors, and fit range. I required this for constructing a table for my paper, but it seems useful.
iv) The minimisation steps (e.g. migrad, simplex, scan) now systematically ramp up until a minimum is found. I also changed the default minimisation algorithm to migrad alone, which speeds up the fitting because scan takes a while.