### PR TITLE
Consistent refs

### DIFF
--- a/pulsar_spectra/spectral_fit.py
+++ b/pulsar_spectra/spectral_fit.py
@@ -80,7 +80,7 @@ def huber_loss_function(sq_resi, k=1.345):
 
 def plot_fit(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref, model, iminuit_result, fit_info,
              plot_error=True, save_name="fit.png", alternate_style=False, axis=None,
-             secondary_fit=False, fit_range=None):
+             secondary_fit=False, fit_range=None, ref_markers=None):
     """Create a plot of the pulsar spectral fit.
 
     Parameters
@@ -111,14 +111,20 @@ def plot_fit(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref, model, iminuit_result, fi
         Plot model with an alternate style and without markers. |br| Default: False.
     fit_range : `tuple`, (`float`, `float`) optional
         Frequency range to plot the second model over in MHz, eg. (100, 3000). |br| Default: None, will use input frequency range.
+    ref_markers : `dict` [`str`, `tuple`], optional
+        Used to overwrite the data marker defaults. The key is the reference name and the tuple contains (color, marker, markersize). |br| Default: None.
     """
+    if ref_markers is None:
+        ref_markers = {}
+
     # Set up plot
     plotsize = 3.2
-
     if axis is None:
         fig, ax = plt.subplots(figsize=(plotsize*4/3, plotsize))
     else:
         ax = axis
+
+    # Set up default mpl markers
     capsize = 1.5
     errorbar_linewidth = 0.7
     marker_border_thickness = 0.5
@@ -152,6 +158,14 @@ def plot_fit(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref, model, iminuit_result, fi
     data_dict = convert_cat_list_to_dict({"dummy_pulsar":[freqs_MHz, fluxs_mJy, flux_errs_mJy, ref]})["dummy_pulsar"]
     if not secondary_fit:
         for ref in data_dict.keys():
+            if ref in ref_markers.keys():
+                # ref in user define marker so use theirs
+                color, marker, markersize = ref_markers[ref]
+            else:
+                # Use our defaults
+                color = None
+                marker = None
+                markersize = None
             freqs_ref = np.array(data_dict[ref]['Frequency MHz'])
             fluxs_ref = np.array(data_dict[ref]['Flux Density mJy'])
             flux_errs_ref = np.array(data_dict[ref]['Flux Density error mJy'])
@@ -164,7 +178,10 @@ def plot_fit(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref, model, iminuit_result, fi
                 markeredgewidth=marker_border_thickness,
                 elinewidth=errorbar_linewidth,
                 capsize=capsize,
-                label=ref.replace('_',' ')
+                label=ref.replace('_',' '),
+                color=color,
+                marker=marker,
+                markersize=markersize,
             )
             for cap in caps:
                 cap.set_markeredgewidth(errorbar_linewidth)
@@ -237,7 +254,8 @@ def iminuit_fit_spectral_model(
         alternate_style=False,
         axis=None,
         secondary_fit=False,
-        fit_range=None
+        fit_range=None,
+        ref_markers=None,
     ):
     """Fit pulsar spectra with iminuit.
 
@@ -274,6 +292,8 @@ def iminuit_fit_spectral_model(
         Plot model with an alternate style and without markers. |br| Default: False.
     fit_range : `tuple`, optional
         Frequency range to plot the second model over. |br| Default: None.
+    ref_markers : `dict` [`str`, `tuple`], optional
+        Used to overwrite the data marker defaults. The key is the reference name and the tuple contains (color, marker, markersize). |br| Default: None.
 
     Returns
     -------
@@ -367,7 +387,8 @@ def iminuit_fit_spectral_model(
         plot_fit(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref, model_function, m, fit_info,
                 save_name=save_name, plot_error=plot_error,
                 alternate_style=alternate_style, axis=axis,
-                secondary_fit=secondary_fit, fit_range=fit_range)
+                secondary_fit=secondary_fit, fit_range=fit_range,
+                ref_markers=ref_markers)
 
     return aic, m, fit_info
 
@@ -375,7 +396,7 @@ def iminuit_fit_spectral_model(
 def find_best_spectral_fit(pulsar, freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all,
                            plot_all=False, plot_best=False, plot_compare=False,
                            plot_error=True, alternate_style=False, axis=None,
-                           secondary_fit=False, fit_range=None):
+                           secondary_fit=False, fit_range=None, ref_markers=None):
     """Fit pulsar spectra with iminuit.
 
     Parameters
@@ -406,6 +427,8 @@ def find_best_spectral_fit(pulsar, freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all,
         Plot model with an alternate style and without markers. Does not work for comparison plots. |br| Default: False.
     fit_range : `tuple`, optional
         Frequency range to plot the second model over. |br| Default: None.
+    ref_markers : `dict` [`str`, `tuple`], optional
+        Used to overwrite the data marker defaults. The key is the reference name and the tuple contains (color, marker, markersize). |br| Default: None.
 
     Returns
     -------
@@ -439,7 +462,7 @@ def find_best_spectral_fit(pulsar, freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all,
         model_function, short_name, start_params, mod_limits = model_dict[model_name]
         aic, iminuit_result, fit_info = iminuit_fit_spectral_model(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all,
                         model_name=model_name, plot=plot_all, plot_error=plot_error, save_name=f"{pulsar}_{model_name}_fit.png",
-                        alternate_style=alternate_style, axis=axis, secondary_fit=secondary_fit)
+                        alternate_style=alternate_style, axis=axis, secondary_fit=secondary_fit, ref_markers=ref_markers)
         logger.debug(f"{model_name} model fit gave AIC {aic}.")
         if iminuit_result is not None:
             aics.append(aic)
@@ -452,7 +475,7 @@ def find_best_spectral_fit(pulsar, freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all,
                 # plot data
                 plot_fit(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all, model_function, iminuit_result, fit_info,
                          plot_error=plot_error, alternate_style=alternate_style,
-                         axis=axs[i], secondary_fit=secondary_fit, fit_range=fit_range)
+                         axis=axs[i], secondary_fit=secondary_fit, fit_range=fit_range, ref_markers=ref_markers)
 
     # Return best result
     if len(aics) == 0:
@@ -495,7 +518,7 @@ def find_best_spectral_fit(pulsar, freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all,
         if plot_best:
             plot_fit(freqs_MHz, fluxs_mJy, flux_errs_mJy, ref_all, model_dict[best_model_name][0], iminuit_results[aici], fit_infos[aici],
                     save_name=f"{pulsar}_{best_model_name}_fit.png", plot_error=plot_error, alternate_style=alternate_style,
-                    axis=axis, secondary_fit=secondary_fit, fit_range=fit_range)
+                    axis=axis, secondary_fit=secondary_fit, fit_range=fit_range, ref_markers=ref_markers)
         return best_model_name, iminuit_results[aici], fit_infos[aici], p_best, p_category
 
 

--- a/tests/test_spectral_fit.py
+++ b/tests/test_spectral_fit.py
@@ -24,12 +24,20 @@ def test_find_best_spectral_fit():
     #pulsars = ['J0820-1350', 'J0835-4510', 'J0837+0610', 'J0953+0755', 'J1453-6413', 'J1456-6843', 'J1645-0317', 'J1731-4744', "J0332+5434"]
     #           spl           bpl           lps           hfto          lfto
     pulsars = ['J0034-0534', 'J0835-4510', 'J1141-6545', 'J1751-4657', 'J0953+0755']
+    ref_markers = {
+        "Jankowski_2018": ("k",       "d", 7),    # black thin diamond
+        "Jankowski_2019": ("#b6dbff", "*", 9),    # light blue star
+        "Xue_2017":       ("y",       "P", 7.5),  # yellow thick plus)
+    }
     for pulsar in pulsars:
         print(f"\nFitting {pulsar}")
         freq_all, flux_all, flux_err_all, ref_all = cat_list[pulsar]
         for freq, flux, flux_err, ref in zip(freq_all, flux_all, flux_err_all, ref_all):
             print(f"{str(freq):8s}{float(flux):8.2f}{float(flux_err):8.2f} {str(ref):20s}")
-        model_name, iminuit_result, fit_info, p_best, p_category = find_best_spectral_fit(pulsar, freq_all, flux_all, flux_err_all, ref_all, plot_compare=True)
+        model_name, iminuit_result, fit_info, p_best, p_category = find_best_spectral_fit(
+            pulsar, freq_all, flux_all, flux_err_all, ref_all,
+            plot_compare=True, ref_markers=ref_markers,
+        )
         print(model_name)
         for p, v, e in zip(iminuit_result.parameters, iminuit_result.values, iminuit_result.errors):
             if p.startswith("v"):


### PR DESCRIPTION
Software updates
- Added a ref_markers argument which can override the plot's default data markers

This wasn't too bad to implement. You can see how I use it in the test. @cplee1 Can you please write up something in the docs about how to use it and show some of your defaults. This may be worth putting in its own plotting section and we could add the multi-fit line stuff we do to the documentation at the same time